### PR TITLE
簡化 useQuestionManager

### DIFF
--- a/src/scenes/ChallengeMode/ChallengeMode.js
+++ b/src/scenes/ChallengeMode/ChallengeMode.js
@@ -126,10 +126,7 @@ export default function ChallengeMode({ onBack }) {
    */
   const generateNewZombie = useCallback(() => {
     // Select question with current difficulty and zombie count
-    const question = questionManager.selectQuestion(
-      gameState.currentDifficulty,
-      gameState.zombiesDefeated + 1
-    );
+    const question = questionManager.selectQuestion();
 
     if (!question) {
       console.warn('No question available for difficulty:', gameState.currentDifficulty);

--- a/src/scenes/ChallengeMode/hooks/useQuestionManager.js
+++ b/src/scenes/ChallengeMode/hooks/useQuestionManager.js
@@ -1,23 +1,26 @@
 import { useState, useCallback, useRef } from 'react';
+import { GAME_CONFIG } from '../gameConfig';
 
 /**
- * Custom hook to manage question selection, candidate pool, and answer statistics
+ * Custom hook to manage question selection and difficulty progression
+ * 
+ * Core features:
+ * - Selects questions with difficulty based on completion rate
+ * - Tracks correctly answered questions
+ * - Manages question pool with immediate updates using refs
  *
  * @param {Object} gameState - Current game state
  * @param {Function} updateGameState - Function to update game state
- * @returns {Object} Question management functions and state
+ * @returns {Object} Question management API
  */
 export const useQuestionManager = (gameState, updateGameState) => {
-  // Candidate pool - questions that have appeared
-  const [candidatePool, setCandidatePool] = useState({});
-
-  // Answer statistics - for accuracy calculation
-  const [answerStats, setAnswerStats] = useState({});
+  // Store candidate pool (correctly answered questions) as ref for immediate updates
+  const candidatePoolRef = useRef([]);
 
   // Currently selected question
   const [currentQuestion, setCurrentQuestion] = useState(null);
 
-  // Reference to current theme sample
+  // Current theme question pool by difficulty
   const currentSampleRef = useRef({
     beginner: [],
     medium: [],
@@ -25,263 +28,216 @@ export const useQuestionManager = (gameState, updateGameState) => {
   });
 
   /**
-   * Update current theme sample pool
-   * @param {Object} sample - Current theme sample with questions of various difficulties
+   * Generates a unique ID for a question
+   */
+  const generateQuestionId = useCallback((question) => {
+    if (question.id) return question.id;
+    
+    // Generate ID from key properties for stability
+    const idParts = [];
+    if (question.type) idParts.push(question.type);
+    if (question.description) idParts.push(question.description);
+    if (question.answer) idParts.push(question.answer);
+    
+    return idParts.length > 0 ? idParts.join('_') : JSON.stringify(question);
+  }, []);
+
+  /**
+   * Updates the question pool with a new set of questions
+   * Resets candidate pool when theme changes
    */
   const updateSamplePool = useCallback((sample) => {
-    currentSampleRef.current = sample;
+    // Add IDs and difficulty markers to all questions
+    const processedSample = {
+      beginner: (sample.beginner || []).map(q => ({ 
+        ...q, 
+        _qid: generateQuestionId(q),
+        difficulty: 'beginner' 
+      })),
+      medium: (sample.medium || []).map(q => ({ 
+        ...q, 
+        _qid: generateQuestionId(q),
+        difficulty: 'medium' 
+      })),
+      hard: (sample.hard || []).map(q => ({ 
+        ...q, 
+        _qid: generateQuestionId(q),
+        difficulty: 'hard' 
+      }))
+    };
+    
+    currentSampleRef.current = processedSample;
+    candidatePoolRef.current = [];
+  }, [gameState.currentTheme, generateQuestionId]);
+
+  /**
+   * Calculates completion rate based on answered questions
+   */
+  const getCompletionRate = useCallback(() => {
+    const total = GAME_CONFIG.SAMPLE_SIZE;
+    const answered = candidatePoolRef.current.length;
+    return total > 0 ? answered / total : 0;
   }, []);
 
   /**
-   * Select a question based on difficulty
-   * Implements non-decreasing difficulty selection logic
-   * @param {string} difficulty - Target difficulty
-   * @param {number} zombieCount - Current zombie count (for non-decreasing difficulty)
-   * @returns {Object} Selected question
+   * Selects a question with dynamic difficulty based on completion rate
+   * Uses a weighted random selection (roulette wheel) approach
    */
-  const selectQuestion = useCallback((difficulty, zombieCount = 1) => {
-    // If no questions of current difficulty, try lower difficulty
-    const difficulties = ['beginner', 'medium', 'hard'];
-    const difficultyIndex = difficulties.indexOf(difficulty);
-
-    // Choose appropriate difficulty based on zombie count and non-decreasing principle
-    let targetDifficulty = difficulty;
-
-    // First zombie uses lowest difficulty questions
-    if (zombieCount === 1) {
-      // Start from lowest difficulty and find available questions
-      for (let i = 0; i <= difficultyIndex; i++) {
-        if (currentSampleRef.current[difficulties[i]]?.length > 0) {
-          targetDifficulty = difficulties[i];
+  const selectQuestion = useCallback(() => {
+    // Calculate remaining questions by difficulty
+    const remainingByDifficulty = {
+      beginner: currentSampleRef.current.beginner?.length || 0,
+      medium: currentSampleRef.current.medium?.length || 0,
+      hard: currentSampleRef.current.hard?.length || 0
+    };
+    
+    const totalRemaining = remainingByDifficulty.beginner + 
+                           remainingByDifficulty.medium + 
+                           remainingByDifficulty.hard;
+    
+    // Handle edge case: no questions remaining
+    if (totalRemaining === 0) return null;
+    
+    // Get current completion rate
+    const completionRate = getCompletionRate();
+    
+    // Determine weights based on completion rate (progression curve)
+    let weights;
+    
+    if (completionRate < 0.2) {
+      // Early stage: mostly beginner questions
+      weights = { beginner: 0.8, medium: 0.15, hard: 0.05 };
+    } else if (completionRate < 0.4) {
+      // Early-mid transition
+      weights = { beginner: 0.6, medium: 0.3, hard: 0.1 };
+    } else if (completionRate < 0.6) {
+      // Mid stage: focus on medium difficulty
+      weights = { beginner: 0.3, medium: 0.5, hard: 0.2 };
+    } else if (completionRate < 0.8) {
+      // Mid-late transition
+      weights = { beginner: 0.2, medium: 0.5, hard: 0.3 };
+    } else {
+      // Final stage: focus on hard questions
+      weights = { beginner: 0.1, medium: 0.3, hard: 0.6 };
+    }
+    
+    // Adjust weights based on available questions
+    const adjustedWeights = {
+      beginner: remainingByDifficulty.beginner > 0 ? weights.beginner : 0,
+      medium: remainingByDifficulty.medium > 0 ? weights.medium : 0,
+      hard: remainingByDifficulty.hard > 0 ? weights.hard : 0
+    };
+    
+    // Normalize weights to sum to 1
+    const sumWeights = adjustedWeights.beginner + adjustedWeights.medium + adjustedWeights.hard;
+    
+    if (sumWeights === 0) {
+      // Edge case: use remaining question counts as weights
+      adjustedWeights.beginner = remainingByDifficulty.beginner / totalRemaining;
+      adjustedWeights.medium = remainingByDifficulty.medium / totalRemaining;
+      adjustedWeights.hard = remainingByDifficulty.hard / totalRemaining;
+    } else {
+      // Standard normalization
+      adjustedWeights.beginner /= sumWeights;
+      adjustedWeights.medium /= sumWeights;
+      adjustedWeights.hard /= sumWeights;
+    }
+    
+    // Roulette wheel selection for difficulty
+    const random = Math.random();
+    let targetDifficulty;
+    
+    if (random < adjustedWeights.beginner) {
+      targetDifficulty = 'beginner';
+    } else if (random < adjustedWeights.beginner + adjustedWeights.medium) {
+      targetDifficulty = 'medium';
+    } else {
+      targetDifficulty = 'hard';
+    }
+    
+    // Find questions of selected difficulty or fallback to any available difficulty
+    let finalPool = currentSampleRef.current[targetDifficulty];
+    
+    if (!finalPool || finalPool.length === 0) {
+      // Try alternative difficulties if target has no questions
+      const difficulties = ['beginner', 'medium', 'hard'];
+      for (const diff of difficulties) {
+        if (currentSampleRef.current[diff]?.length > 0) {
+          targetDifficulty = diff;
+          finalPool = currentSampleRef.current[diff];
           break;
         }
       }
-    }
-    // Zombies 2-4 use same or higher difficulty
-    else if (zombieCount >= 2 && zombieCount <= 4) {
-      // Start from target difficulty and find available questions
-      let found = false;
-      for (let i = difficultyIndex; i < difficulties.length; i++) {
-        if (currentSampleRef.current[difficulties[i]]?.length > 0) {
-          targetDifficulty = difficulties[i];
-          found = true;
-          break;
-        }
-      }
-
-      // If no higher difficulty available, fall back to lower difficulties
-      if (!found) {
-        for (let i = difficultyIndex - 1; i >= 0; i--) {
-          if (currentSampleRef.current[difficulties[i]]?.length > 0) {
-            targetDifficulty = difficulties[i];
-            break;
-          }
-        }
+      
+      // If still no questions available, return null
+      if (!finalPool?.length) {
+        return null;
       }
     }
-    // Last zombie preferably uses highest difficulty
-    else if (zombieCount === 5) {
-      if (currentSampleRef.current.hard?.length > 0) {
-        targetDifficulty = 'hard';
-      } else if (currentSampleRef.current.medium?.length > 0) {
-        targetDifficulty = 'medium';
-      } else {
-        targetDifficulty = 'beginner';
-      }
-    }
-
-    // No available questions
-    if (
-      !currentSampleRef.current[targetDifficulty] ||
-      currentSampleRef.current[targetDifficulty].length === 0
-    ) {
-      return null;
-    }
-
-    // Randomly select a question
-    const pool = currentSampleRef.current[targetDifficulty];
-    const randomIndex = Math.floor(Math.random() * pool.length);
-    const selectedQuestion = { ...pool[randomIndex] };
-
-    // Remove selected question from sample pool
-    currentSampleRef.current[targetDifficulty] = [
-      ...pool.slice(0, randomIndex),
-      ...pool.slice(randomIndex + 1)
-    ];
-
-    // Set current question
+    
+    // Randomly select a question from the chosen difficulty
+    const randomIndex = Math.floor(Math.random() * finalPool.length);
+    const selectedQuestion = { ...finalPool[randomIndex] };
+    
     setCurrentQuestion(selectedQuestion);
     return selectedQuestion;
-  }, []);
+  }, [getCompletionRate]);
 
   /**
-   * Handle correct answer
-   * Update accuracy statistics and add question to candidate pool
-   * @param {Object} answerData - Answer related data
+   * Handles correct answer:
+   * - Removes question from question pool
+   * - Adds to candidate pool
    */
   const onCorrectAnswer = useCallback(
     (answerData) => {
-      const { question, theme = gameState.currentTheme } = answerData;
-
-      // Return if no question data
+      const { question } = answerData;
       if (!question) return;
-
-      // Update answer statistics
-      setAnswerStats((prev) => {
-        const themeStats = prev[theme] || {
-          correct: 0,
-          total: 0,
-          questions: {}
-        };
-
-        // Update question-specific statistics
-        const questionId = question.id || JSON.stringify(question);
-        const questionStats = themeStats.questions[questionId] || { correct: 0, attempts: 0 };
-
-        return {
-          ...prev,
-          [theme]: {
-            correct: themeStats.correct + 1,
-            total: themeStats.total + 1,
-            questions: {
-              ...themeStats.questions,
-              [questionId]: {
-                correct: questionStats.correct + 1,
-                attempts: questionStats.attempts + 1,
-                question
-              }
-            }
-          }
-        };
-      });
-
-      // Add question to candidate pool
-      setCandidatePool((prev) => {
-        const themePool = prev[gameState.currentTheme] || {
-          beginner: [],
-          medium: [],
-          hard: []
-        };
-
-        // Check if question already exists in candidate pool
-        const difficulty = question.difficulty || 'beginner';
-        const questionId = question.id || JSON.stringify(question);
-        const exists = themePool[difficulty].some(
-          (q) => (q.id && q.id === questionId) || JSON.stringify(q) === JSON.stringify(question)
-        );
-
-        if (!exists) {
-          return {
-            ...prev,
-            [gameState.currentTheme]: {
-              ...themePool,
-              [difficulty]: [...themePool[difficulty], question]
-            }
-          };
-        }
-
-        return prev;
-      });
+      
+      const difficulty = question.difficulty;
+      if (!difficulty || !currentSampleRef.current[difficulty]) return;
+      
+      const questionId = question._qid || generateQuestionId(question);
+      
+      // Remove from question pool
+      currentSampleRef.current[difficulty] = currentSampleRef.current[difficulty].filter(q => 
+        q._qid !== questionId
+      );
+      
+      // Add to candidate pool
+      const questionToAdd = {
+        ...question,
+        _qid: questionId,
+        difficulty
+      };
+      
+      candidatePoolRef.current.push(questionToAdd);
     },
-    [gameState.currentTheme]
+    [generateQuestionId]
   );
 
   /**
-   * Handle wrong answer
-   * Update accuracy statistics
-   * @param {Object} answerData - Answer related data
+   * Handles wrong answer (question remains in pool)
    */
-  const onWrongAnswer = useCallback(
-    (answerData) => {
-      const { question, theme = gameState.currentTheme } = answerData;
-
-      // Return if no question data
-      if (!question) return;
-
-      // Update answer statistics
-      setAnswerStats((prev) => {
-        const themeStats = prev[theme] || {
-          correct: 0,
-          total: 0,
-          questions: {}
-        };
-
-        // Update question-specific statistics
-        const questionId = question.id || JSON.stringify(question);
-        const questionStats = themeStats.questions[questionId] || { correct: 0, attempts: 0 };
-
-        return {
-          ...prev,
-          [theme]: {
-            correct: themeStats.correct,
-            total: themeStats.total + 1,
-            questions: {
-              ...themeStats.questions,
-              [questionId]: {
-                correct: questionStats.correct,
-                attempts: questionStats.attempts + 1,
-                question
-              }
-            }
-          }
-        };
-      });
-    },
-    [gameState.currentTheme]
-  );
+  const onWrongAnswer = useCallback(() => {}, []);
 
   /**
-   * Calculate accuracy for current theme
-   * @returns {number} Accuracy percentage (0-100)
-   */
-  const getThemeAccuracy = useCallback(() => {
-    const theme = gameState.currentTheme;
-    const stats = answerStats[theme];
-
-    if (!stats || stats.total === 0) return 0;
-    return Math.round((stats.correct / stats.total) * 100);
-  }, [answerStats, gameState.currentTheme]);
-
-  /**
-   * Get accuracy statistics for current theme
-   * Provide to LevelManager for Boss Level determination
-   * @returns {Object} Current theme statistics
-   */
-  const getThemeStats = useCallback(() => {
-    const theme = gameState.currentTheme;
-    return answerStats[theme] || { correct: 0, total: 0 };
-  }, [answerStats, gameState.currentTheme]);
-
-  /**
-   * Get questions from candidate pool for specified difficulty
-   * For Boss-Level and other special cases
-   * @param {string} difficulty - Difficulty to retrieve
-   * @returns {Array} List of candidate questions for the difficulty
+   * Returns questions from candidate pool for specific difficulty
    */
   const getCandidateQuestions = useCallback(
-    (difficulty) => {
-      const theme = gameState.currentTheme;
-      const pool = candidatePool[theme];
-
-      if (!pool || !pool[difficulty]) return [];
-      return [...pool[difficulty]];
-    },
-    [candidatePool, gameState.currentTheme]
+    (difficulty) => candidatePoolRef.current.filter(q => q.difficulty === difficulty),
+    []
   );
 
   /**
-   * Clear candidate pool for current theme
+   * Clears candidate pool
    */
   const clearCandidatePool = useCallback(() => {
-    setCandidatePool((prev) => ({
-      ...prev,
-      [gameState.currentTheme]: {
-        beginner: [],
-        medium: [],
-        hard: []
-      }
-    }));
-  }, [gameState.currentTheme]);
+    candidatePoolRef.current = [];
+  }, []);
+
+  // Stub functions for backward compatibility
+  const getThemeAccuracy = useCallback(() => 0, []);
+  const getThemeStats = useCallback(() => ({ correct: 0, total: 0 }), []);
 
   return {
     updateSamplePool,


### PR DESCRIPTION
## 描述

修改 `useQuestionManager` 中的各項功能

### 簡化選題邏輯

原本的選題邏輯使用 `difficulty` 和 `zombieCount` 兩個參數來決定下一個問題的難度再進行抽選，邏輯不清晰且不易追蹤。在這個方案中使用 `完成率` 這個指標來控制三個難度的權重，並透過輪盤抽選來決定將抽選題目的難度，再從該難度的題庫中取出一題。

### 移除主題正確率計算

因為正確率的計算方式為 `候選題池題數` / `總題數`，與完成率的計算公式相同，因此移除了正確率的計算部分，直接使用完成率取代之前的正確率。

### 簡化程式碼

縮短整體程式碼約 100 來行。

相關的 issue #無

## 變更的類型

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 影響的頁面

- [ ] MainMenu
- [X] ChallengeMode
- [ ] Option
- [ ] StoryMode
- [ ] 其他（請填寫）

## 檢查清單

- [X] 我已經在本地手動測試過，確保功能的完整性和穩定性
- [X] 我對我的程式碼進行了註解，特別是在難以理解的地方
- [X] 我已經更新了文件，或者我的更改不需要更新文件
- [X] 我的 PR 有明確的標題與內容描述
