### PR TITLE
add restart button in ChellengeMode & expand themepool

### DIFF
--- a/src/scenes/ChallengeMode/SummaryPage.jsx
+++ b/src/scenes/ChallengeMode/SummaryPage.jsx
@@ -1,0 +1,9 @@
+export default function SummaryPage({ onBack, onRestart }) {
+  return (
+    <>
+      <h1>Game Summary Page</h1>
+      <button onClick={onBack}>Menu</button>
+      <button onClick={onRestart}>重新開始</button>
+    </>
+  );
+}

--- a/src/scenes/ChallengeMode/gameConfig.js
+++ b/src/scenes/ChallengeMode/gameConfig.js
@@ -7,7 +7,28 @@ export const GAME_CONFIG = {
   ACCURACY_THRESHOLD: 0.9,
   SAMPLE_SIZE: 50,
   INITIAL_DIFFICULTY: 'beginner',
-  THEME_POOL: ['food', 'clothing', 'weather', 'sports', 'professions', 'technology', 'color'],
+  THEME_POOL: [
+    'animal',
+    'art',
+    'body and health',
+    'clothes',
+    'crime',
+    'education',
+    'describe',
+    'food',
+    'house',
+    'money',
+    'nature',
+    'actions',
+    'appearence',
+    'personality',
+    'politics',
+    'relationships',
+    'shopping',
+    'technology',
+    'travel',
+    'work'
+  ],
   DIFFICULTY_LEVELS: {
     BEGINNER: 1,
     MEDIUM: 2,
@@ -40,5 +61,5 @@ export const GAME_CONFIG = {
       volume: 1
     }
     // Add more sound effects here
-  },
+  }
 };

--- a/src/scenes/ChallengeMode/hooks/useGameState.js
+++ b/src/scenes/ChallengeMode/hooks/useGameState.js
@@ -7,11 +7,19 @@ import { useCallback, useReducer } from 'react';
  * @returns {Object} New game state
  */
 const gameStateReducer = (state, action) => {
-  // Handle functional updates (when action is a function)
   if (typeof action === 'function') {
     return action(state);
   }
-  // Handle object updates (regular updates)
+  if (action.type === 'initial') {
+    return {
+      level: 1,
+      lives: 3,
+      zombiesDefeated: 0,
+      gameOver: false,
+      currentTheme: '',
+      remainingThemes: []
+    };
+  }
   return { ...state, ...action };
 };
 
@@ -41,8 +49,15 @@ export const useGameState = () => {
     dispatch(updates);
   }, []);
 
+  const initializeGameState = useCallback(() => {
+    dispatch({
+      type: 'initial'
+    });
+  }, []);
+
   return {
     gameState,
-    updateGameState
+    updateGameState,
+    initializeGameState
   };
 };

--- a/src/scenes/ChallengeMode/hooks/useThemeManager.js
+++ b/src/scenes/ChallengeMode/hooks/useThemeManager.js
@@ -47,7 +47,7 @@ export const useThemeManager = (gameState, updateGameState) => {
       allThemeData.current = data;
       return data;
     } catch (error) {
-      console.error('Failed to load theme data:', error);
+      console.error('useThemeManager: Failed to load theme data:', error);
       return null;
     }
   }, []);
@@ -60,12 +60,12 @@ export const useThemeManager = (gameState, updateGameState) => {
   const selectNextTheme = useCallback(() => {
     // Use temporary themeList variable to track correct values
     let themeList = [];
-    
+
     if (!gameState.remainingThemes || gameState.remainingThemes.length === 0) {
-      console.log('useThemeManager: Refilling the pool');
+      console.log('useThemeManager: Refilling theme pool');
       // If theme pool is empty, use the complete theme pool and shuffle it
       themeList = shuffleArray([...GAME_CONFIG.THEME_POOL]);
-      
+
       // Update state (this won't take effect immediately, but it's fine as we have correct values in themeList)
       updateGameState({
         remainingThemes: [...themeList]
@@ -77,10 +77,10 @@ export const useThemeManager = (gameState, updateGameState) => {
 
     // Select first theme from temporary variable
     const nextTheme = themeList[0];
-    
+
     // Remove first theme from temporary variable
     const updatedThemes = themeList.slice(1);
-    
+
     // Update remaining themes in state
     updateGameState({
       currentTheme: nextTheme,
@@ -179,29 +179,28 @@ export const useThemeManager = (gameState, updateGameState) => {
     }
 
     // Select and switch to next theme
-    const nextTheme = selectNextTheme();
-    createThemeSample(nextTheme);
+    selectNextTheme();
   }, [selectNextTheme, createThemeSample, gameState.currentTheme, updateGameState]);
 
   // Initialize theme data on first load
   useEffect(() => {
     async function initializeThemeData() {
       if (isInitialized.current) return;
-      
+
       console.log('useThemeManager: Fetching raw data...');
       const data = await loadThemeData();
-      
+
       if (data) {
         console.log('useThemeManager: Data loaded.');
         isInitialized.current = true;
-        
+
         // Only set theme if not already set
         if (!gameState.currentTheme || gameState.currentTheme === '') {
           selectNextTheme();
         }
       }
     }
-    
+
     initializeThemeData();
   }, []); // Empty dependency array to ensure it runs only once
 


### PR DESCRIPTION
## 描述

### 新增 `SummaryPage` Component 控制遊戲結算頁面
- 加入 `重新遊戲` 按鈕可以直接重新開始遊戲，不用回到菜單再點一次
- 在 `ChallengeMode` 中直接進行初始化

### 結合最新的題庫內容
- 擴充 `GameConfig` 中的主題池列表

相關的 issue #無

## 變更的類型

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 影響的頁面

- [ ] MainMenu
- [X] ChallengeMode
- [ ] Option
- [ ] StoryMode
- [ ] 其他（請填寫）

## 檢查清單

- [X] 我已經在本地手動測試過，確保功能的完整性和穩定性
- [X] 我對我的程式碼進行了註解，特別是在難以理解的地方
- [X] 我已經更新了文件，或者我的更改不需要更新文件
- [X] 我的 PR 有明確的標題與內容描述
